### PR TITLE
Make canvas command more easily usable

### DIFF
--- a/canvas/__main__.py
+++ b/canvas/__main__.py
@@ -14,7 +14,8 @@ from canvas.cli.base import TokenCacheException
 from .oauth import CanvasAuth
 from canvas.cli.manager import CommandManager
 
-async def main() -> None:
+
+async def a_main() -> None:
     """The main entry point for the CLI."""
 
     parser = CommandManager.get_command_parser()
@@ -63,6 +64,10 @@ async def main() -> None:
     cmd.execute()
 
 
-if __name__ == "__main__":
+def main():
     load_dotenv()
-    asyncio.run(main())
+    asyncio.run(a_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT" # TODO: Remove placeholder license once decided by team members.
 
 keywords = ["canvas"]
 homepage = "https://github.com/EOF-D/CSI-280-Canvas-Git"
-packages = [{include = "canvas"}]
+packages = [ {include = "canvas"} ]
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -25,6 +25,9 @@ pytest = "^8.3.4"
 pytest-cov = "^6.0.0"
 pytest-asyncio = "^0.25.3"
 coverage = "^7.6.12"
+
+[tool.poetry.scripts]
+canvas = "canvas.__main__:main"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Made it so you can do
```ps
canvas command_name
```
rather than
```ps
py -m canvas command_name
```